### PR TITLE
Fix one instance of non-https curl

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -59,7 +59,7 @@ def fetch(f):
             os.system("curl -O https://www.unicode.org/Public/emoji/%s.%s/%s"
                       % (UNICODE_VERSION[0], UNICODE_VERSION[1], f))
         else:
-            os.system("curl -O http://www.unicode.org/Public/%s/ucd/%s"
+            os.system("curl -O https://www.unicode.org/Public/%s/ucd/%s"
                       % (UNICODE_VERSION_NUMBER, f))
 
     if not os.path.exists(os.path.basename(f)):


### PR DESCRIPTION
http -> https cleanup similar to [a recent unicode-security pr](https://github.com/unicode-rs/unicode-security/pull/24); a comment in that repo's unicode.py hinted that this repo had a similar script

https://github.com/unicode-rs/unicode-script/blob/974eb90def61add638712df77f7fae01979410b7/scripts/unicode.py#L58-L63

(apologies if these are noisy, I know they're not very substantive)